### PR TITLE
Add helpers, update code

### DIFF
--- a/spec/acceptance/nodesets/centos7-pooler.yml
+++ b/spec/acceptance/nodesets/centos7-pooler.yml
@@ -1,0 +1,21 @@
+HOSTS:
+  rhel7:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  type: foss

--- a/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/spec/acceptance/nodesets/docker/centos-7.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  centos-7-x64:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    hypervisor: docker
+    image: centos:7
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    # install various tools required to get the image up to usable levels
+    docker_image_commands:
+      - 'yum install -y crontabs tar wget openssl sysvinit-tools iproute which initscripts'
+CONFIG:
+  trace_limit: 200
+  nfs_server: none
+  consoleport: 443

--- a/spec/acceptance/nodesets/docker/debian-8.yml
+++ b/spec/acceptance/nodesets/docker/debian-8.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  debian-8-x64:
+    platform: debian-8-amd64
+    hypervisor: docker
+    image: debian:8
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-1404-x64:
+    platform: ubuntu-14.04-amd64
+    hypervisor: docker
+    image: ubuntu:14.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      # ensure that upstart is booting correctly in the container
+      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/status_spec.rb
+++ b/spec/acceptance/status_spec.rb
@@ -11,24 +11,41 @@ describe 'package task' do
         }
       EOS
     end
-    it 'should apply with no errors' do
-      apply_manifest(pp, :catch_failures => true)
+
+    it 'applies with no errors' do
+      apply_manifest(pp, catch_failures: true)
     end
 
-    it 'should apply a second time without changes', :skip_pup_5016 do
-      apply_manifest(pp, :catch_changes => true)
+    it 'applies a second time without changes', :skip_pup_5016 do
+      apply_manifest(pp, catch_changes: true)
     end
   end
-  describe 'run a simple init task' do
-    result = run_task(task_name: 'init')
-    expect(result).to match(/declare -x OLDPWD/)
-    # example cli 
-    # bolt run /etc/puppetlabs/code/modules/package/tasks/init --nodes localhost --password vagrant
-    # bolt exec --nodes localhost --password vagrant command='ls -l /'
-    # /opt/puppetlabs/puppet/bin/ruby /etc/puppetlabs/code/modules/package/tasks/status
-    # then type 
-    # { "name": "vim" }
-    # then hit <enter>
-    # then <CTRL> + d
+  describe 'init task' do
+    it 'runs with bolt' do
+      result = run_bolt_task(module_name: 'package', task_name: 'init')
+      expect(result).to match(/declare -x OLDPWD/)
+      # example cli 
+      # bolt run /etc/puppetlabs/code/modules/package/tasks/init --nodes localhost --password vagrant
+      # bolt exec --nodes localhost --password vagrant command='ls -l /'
+      # /opt/puppetlabs/puppet/bin/ruby /etc/puppetlabs/code/modules/package/tasks/status
+      # then type 
+      # { "name": "vim" }
+      # then hit <enter>
+      # then <CTRL> + d
+    end
+    it 'runs with puppet task' do
+      result = run_puppet_task(task_name: 'package')
+      expect(result).to match(/declare -x OLDPWD/)
+    end
+  end
+  describe 'package::status task' do
+    it 'runs with bolt' do
+      result = run_bolt_task(module_name: 'package', task_name: 'status', params: { 'name' => 'vim' })
+      expect(result).to match(/declare -x OLDPWD/)
+    end
+    it 'runs with puppet task' do
+      result = run_puppet_task(task_name: 'package::status', params: { 'name' => 'vim' })
+      expect(result).to match(/declare -x OLDPWD/)
+    end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,8 +10,25 @@ install_module_dependencies_on(hosts)
 
 UNSUPPORTED_PLATFORMS = ['Windows', 'Solaris', 'AIX']
 
-def run_task(task_name:, args: nil)
-  on(default, "bolt run /etc/puppetlabs/code/modules/package/tasks/#{task_name} --nodes localhost --password vagrant", { :acceptable_exit_codes => [0,1] }).stdout
+DEFAULT_PASSWORD = if master[:hypervisor] == 'vagrant'
+                     'vagrant'
+                   elsif master[:hypervisor] == 'vcloud'
+                     '~!@#$%^*-/ aZ'
+                   end
+
+def run_puppet_access_login(user:, password: DEFAULT_PASSWORD, lifetime: "5y")
+  # FIXME: read user/password on stdin
+  on(master, puppet('access', 'login', user, password, '--lifetime', lifetime))
+end
+
+def run_bolt_task(module_name:, task_name:, params: nil, password: DEFAULT_PASSWORD)
+  on(master, "bolt run /etc/puppetlabs/code/environments/production/modules/#{module_name}/tasks/#{task_name} --nodes localhost --password #{password}", acceptable_exit_codes: [0, 1]).stdout
+end
+
+def run_puppet_task(task_name:, params: nil)
+  # FIXME: adreyer says "I thought the not passing environment bug was fixed" so --environment may not be needed
+  # FIXME: check how apply_manifest() does temp files for the params file
+  on(master, puppet('task', 'run', task_name, '--nodes', fact_on(master, 'fqdn'), '--environment', 'production', '--params-file', tempfile), acceptable_exit_codes: [0, 1]).stdout
 end
 
 RSpec.configure do |c|
@@ -20,20 +37,22 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    hosts.each do |host|
-      # fix the path
-      on(host, "echo PATH=\"$PATH:/opt/puppetlabs/puppet/bin\"  >> /etc/bash.bashrc")
-      
-      scp_to(default, "bolt-0.0.6.gem", '/tmp')
-pp=<<-EOS
-package { 'net-netconf' :
-  provider => 'puppet_gem',
-  ensure   => 'installed',
-  source   => '/tmp/bolt-0.0.6.gem'
-}
-EOS
-      create_remote_file(default, "/tmp/gems.pp", pp)
-      on host, puppet('apply','/tmp/gems.pp'), {:acceptable_exit_codes => [0,1] }
-    end
+    # fix the path
+    on(master, "echo PATH=\"$PATH:/opt/puppetlabs/puppet/bin\"  >> /etc/bash.bashrc")
+
+    scp_to(master, "bolt-0.0.6.gem", '/tmp')
+    pp = <<-EOS
+    package { 'net-netconf' :
+      provider => 'puppet_gem',
+      ensure   => 'installed',
+      source   => '/tmp/bolt-0.0.6.gem'
+    }
+    EOS
+    create_remote_file(hosts, '/tmp/gems.pp', pp)
+    on(hosts, puppet('apply', '/tmp/gems.pp'), acceptable_exit_codes: [0, 1])
+
+    run_puppet_access_login(user: 'admin', password: '~!@#$%^*-/ aZ')
+    # FIXME: adreyer says "it only supports [code/environments/production/modules] orch is reading it directly and has no access to modulepath"
+    on(master, 'mv /etc/puppetlabs/code/modules/package /etc/puppetlabs/code/environments/production/modules')
   end
 end

--- a/tasks/status.json
+++ b/tasks/status.json
@@ -5,11 +5,11 @@
   "parameters": {
     "name": {
       "description": "The name of the package to inspect",
-      "type": "string"
+      "type": "String"
     },
     "provider": {
       "description": "The provider to use to inspect the package, defaults to the system package manager",
-      "type": "string"
+      "type": "Optional[String]"
     }
   },
   "requiredParameters": ["name"]


### PR DESCRIPTION
Changed:
- split run_task to run_puppet_task and run_bolt_task

Added:
- add docker/pooler nodesets for other testing
- make the tasks take params (not finished)

Fixed:
- Put tests in `it` blocks (they were naked and were unashamed)
- update password handling for pooler
- move the module to the environment location (see comments)
- clean up setup helper code for future master/agent scenarios
- fix the typing validation in status.json
- various linting