### PR TITLE
Fix passwords and other fixmes

### DIFF
--- a/tasks/init
+++ b/tasks/init
@@ -1,4 +1,4 @@
-!/usr/bin/env ruby
+#!/usr/bin/env ruby
 
 require 'json'
 puts({message: ENV['PT_message']}.to_json)


### PR DESCRIPTION
- I was confused on the console password vs. root password. fixed
- No --environment needed any more
- Pass password to `puppet access login` on stdin
- Path to bolt needs to be explicit
- Create tempfile for task params and use it
- Fix shebang on init script

This appears to run everything as expected.

I still get the following, perhaps due to the "not downloading the task" bug.
correctly:
```
  msg : Failed to execute the task for the non blocking 'task run' request (transaction 3). Error: The downloaded init's sha differs from the provided sha
  kind : puppetlabs.orchestrator/execution-failure
```

This may be fixed by https://github.com/puppetlabs/orchestrator/commit/963aa5500117cc14fcb0de9f739659096a2fd421 and just not shipped in a PE build yet.