### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Release 0.1.2
+
+### Fixed
+- Handle providers that return multiple versions (gem)
+- Handle providers that don't have latest (windows)
+- Handle providers that exit 1 when absent (yum)
+
 ## Release 0.1.1
 This is the initial release of the package task.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-package",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "puppet",
   "summary": "Tasks that manipulate a package",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Handle providers that return multiple versions (gem)
- Handle providers that don't have latest (windows)
- Handle providers that exit 1 when absent (yum)