### PR TITLE
(MODULES-8045) Fix apt-get upgrading everything when no version passed and apt is package manager.

### DIFF
--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -28,16 +28,19 @@ do
       if [ "${version}" != "" ]; then
         name="$name-$version"
       fi
+      # upgrading to a specific version needs to use the install action
+      if [ "${version}" != "" ] && [ "${action}" = "upgrade" ]; then
+        action="install"
+      fi
     else
       $(export DEBIAN_FRONTEND=noninteractive)
       if [ "${version}" != "" ]; then
         name="$name=$version"
       fi
-    fi
-
-    # upgrading to a specific version needs to use the install action
-    if [ "${version}" != "" ] && [ "${action}" = "upgrade" ]; then
-      action="install"
+      # upgrading requires install to be used. --only-upgrade will not install new packages
+      if [ "${action}" = "upgrade" ]; then
+        action="install --only-upgrade"
+      fi
     fi
 
     command_line="$package_manager -y $action $name"


### PR DESCRIPTION
**Problem**
https://tickets.puppetlabs.com/browse/MODULES-8045
When using apt the current linux package updates all packages instead of the requested package when no version is specified. This is due to "upgrade" being used as the action. This will upgrade everything.

**Solution**
 When updating a specific package using apt the 'install' argument should be used.  This will update the package if it exists, or install it if it doesn't.

**Testing**
- ad-hoc jenkins pipeline job ran and passed successfully
- manually tested upgrade with the following permutations:
  - upgrade version with no arguments on yum and apt - latest version installed.
  - upgrade version with arguments on yum and apt - the version which was requested was installed.