### PR TITLE
(MODULES-8390) Enable implementations on the init task and hide others

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    package: "#{source_dir}"

--- a/.sync.yml
+++ b/.sync.yml
@@ -5,9 +5,15 @@
     - set: docker/ubuntu-14.04
   docker_defaults:
     bundler_args: ""
+    script: bundle exec rake task_acceptance
   secure: ""
   branches:
     - release
+  remove_includes:
+    - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.4
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8
+      rvm: 2.1.9
 
 Gemfile:
   optional:
@@ -25,6 +31,8 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
+      - gem: 'bolt'
+        version: '~> 1.4'
 
 Rakefile:
   requires:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/centos-7 BEAKER_TESTMODE=apply
       rvm: 2.5.1
-      script: bundle exec rake beaker
+      script: bundle exec rake task_acceptance
       services: docker
       sudo: required
     -
@@ -35,19 +35,13 @@ matrix:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/ubuntu-14.04 BEAKER_TESTMODE=apply
       rvm: 2.5.1
-      script: bundle exec rake beaker
+      script: bundle exec rake task_acceptance
       services: docker
       sudo: required
     -
       env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
       env: CHECK=parallel_spec
-    -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.4
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8 BUNDLER_VERSION=1.17.3
-      rvm: 2.1.9
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-win-system-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "bolt", '~> 1.4',                               require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -75,3 +75,6 @@ EOM
   end
 end
 
+task :task_acceptance => [:spec_prep, :beaker] do
+  # nothing to do
+end

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -16,6 +16,7 @@ describe 'package task' do
   end
 
   operating_system_fact = fact('operatingsystem')
+  redhat_six = fact('os.name') == 'RedHat' && fact('os.release.major') == '6'
 
   describe 'install' do
     before(:all) do
@@ -29,7 +30,7 @@ describe 'package task' do
       expect(result[0]['result']['version']).to match(%r{\d+\.\d+\.\d+})
     end
 
-    it 'returns the version of pry', unless: (operating_system_fact == 'windows') do
+    it 'returns the version of pry', unless: (operating_system_fact == 'windows') || redhat_six do
       result = run('action' => 'status', 'name' => 'pry', 'provider' => 'puppet_gem')
       expect(result[0]['status']).to eq('success')
       expect(result[0]['result']['status']).to eq('up to date')
@@ -40,7 +41,7 @@ describe 'package task' do
   describe 'install without puppet' do
     let(:inventory) { hosts_to_inventory }
 
-    it 'installs rsyslog', unless: (operating_system_fact == 'windows') do
+    it 'installs rsyslog', unless: (operating_system_fact == 'windows') || redhat_six do
       result = run('action' => 'install', 'name' => 'rsyslog')
       expect(result[0]['status']).to eq('success')
       expect(result[0]['result']['status']).to match(%r{install})

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -1,43 +1,79 @@
 # run a test task
 require 'spec_helper_acceptance'
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
 
 describe 'package task' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  let(:module_path) { RSpec.configuration.module_path }
+  let(:config) { { 'modulepath' => module_path } }
+  let(:inventory) { hosts_to_inventory.merge('features' => ['puppet-agent']) }
+
+  def run(params)
+    run_task('package', 'default', params, config: config, inventory: inventory)
+  end
+
+  operating_system_fact = fact('operatingsystem')
+
   describe 'install' do
     before(:all) do
-      apply_manifest('package { "pry": ensure => absent, provider => "puppet_gem", }')
+      apply_manifest_on(default, 'package { "pry": ensure => absent, provider => "puppet_gem", }')
     end
-    it 'installs pry', unless: (fact('operatingsystem') == 'windows') do
-      result = run_task(task_name: 'package', params: 'action=install name=pry provider=puppet_gem')
-      expect_multiple_regexes(result: result, regexes: [%r{installed}, %r{version.*\d+.\d+}, %r{(Job completed. 1/1 nodes succeeded|Ran on 1 node)}])
+
+    it 'installs pry', unless: (operating_system_fact == 'windows') do
+      result = run('action' => 'install', 'name' => 'pry', 'provider' => 'puppet_gem')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to eq('installed')
+      expect(result[0]['result']['version']).to match(%r{\d+\.\d+\.\d+})
     end
-    it 'returns the version of pry', unless: (fact('operatingsystem') == 'windows') do
-      result = run_task(task_name: 'package', params: 'action=status name=pry provider=puppet_gem')
-      expect_multiple_regexes(result: result, regexes: [%r{up to date}, %r{(Job completed. 1/1 nodes succeeded|Ran on 1 node)}])
+
+    it 'returns the version of pry', unless: (operating_system_fact == 'windows') do
+      result = run('action' => 'status', 'name' => 'pry', 'provider' => 'puppet_gem')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to eq('up to date')
+      expect(result[0]['result']['version']).to match(%r{\d+\.\d+\.\d+})
     end
   end
+
+  describe 'install without puppet' do
+    let(:inventory) { hosts_to_inventory }
+
+    it 'installs rsyslog', unless: (operating_system_fact == 'windows') do
+      result = run('action' => 'install', 'name' => 'rsyslog')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to match(%r{install})
+    end
+  end
+
   describe 'uninstall' do
     before(:all) do
-      apply_manifest('package { "pry": ensure => "present", provider => "puppet_gem", }')
+      apply_manifest_on(default, 'package { "pry": ensure => "present", provider => "puppet_gem", }')
     end
 
     it 'uninstalls pry' do
-      result = run_task(task_name: 'package', params: 'action=uninstall name=pry provider=puppet_gem')
-      expect_multiple_regexes(result: result, regexes: [%r{uninstalled}, %r{(Job completed. 1/1 nodes succeeded|Ran on 1 node)}])
+      result = run('action' => 'uninstall', 'name' => 'pry', 'provider' => 'puppet_gem')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to eq('uninstalled')
     end
     it 'status' do
-      result = run_task(task_name: 'package', params: 'action=status name=pry provider=puppet_gem')
-      expect_multiple_regexes(result: result, regexes: [%r{absent}, %r{(Job completed. 1/1 nodes succeeded|Ran on 1 node)}])
+      result = run('action' => 'status', 'name' => 'pry', 'provider' => 'puppet_gem')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to eq('absent')
     end
   end
-  describe 'upgrade', if: (fact('operatingsystem') == 'CentOS' && fact('operatingsystemmajrelease') == '7' && pe_install?) do
-    it 'upgrade httpd to a specific version' do
-      result = run_task(task_name: 'package', params: 'action=upgrade name=httpd version=2.4.6-45.el7.centos')
-      expect_multiple_regexes(result: result, regexes: [%r{version : 2.4.6-45.el7.centos}, %r{Job completed. 1/1 nodes succeeded}])
+
+  describe 'upgrade', if: (operating_system_fact == 'CentOS' && fact('operatingsystemmajrelease') == '7') do
+    before(:all) do
+      apply_manifest_on(default, 'package { "httpd": ensure => "present", }')
     end
 
     it 'upgrade httpd' do
-      result = run_task(task_name: 'package', params: 'action=upgrade name=httpd')
-      expect_multiple_regexes(result: result, regexes: [%r{version : 2.4.6-45.el7.centos.4}, %r{old_version : 2.4.6-45.el7.centos}, %r{Job completed. 1/1 nodes succeeded}])
+      result = run('action' => 'upgrade', 'name' => 'httpd')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['version']).to match(%r{2.4.6-\d+.el7.centos})
+      expect(result[0]['result']['old_version']).to match(%r{2.4.6-\d+.el7.centos})
     end
   end
 end

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -15,8 +15,11 @@ describe 'linux package task', unless: fact('osfamily') == 'windows' do
     run_task('package::linux', 'default', params, config: config, inventory: inventory)
   end
 
+  redhat_six = fact('os.name') == 'RedHat' && fact('os.release.major') == '6'
+  windows = fact('osfamily') == 'windows'
+
   describe 'install action' do
-    it 'install rsyslog' do
+    it 'install rsyslog', unless: redhat_six || windows do
       apply_manifest_on(default, "package { 'rsyslog': ensure => absent, }")
       result = run('action' => 'install', 'name' => 'rsyslog')
       expect(result[0]['status']).to eq('success')
@@ -24,7 +27,7 @@ describe 'linux package task', unless: fact('osfamily') == 'windows' do
     end
   end
 
-  describe 'uninstall action' do
+  describe 'uninstall action', unless: redhat_six || windows do
     it 'uninstall rsyslog' do
       apply_manifest_on(default, "package { 'rsyslog': ensure => present, }")
       result = run('action' => 'uninstall', 'name' => 'rsyslog')

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -1,31 +1,44 @@
 # run a test task
 require 'spec_helper_acceptance'
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
 
-describe 'linux package task', unless: fact_on(default, 'osfamily') == 'windows' do
-  package_to_use = 'rsyslog'
+describe 'linux package task', unless: fact('osfamily') == 'windows' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  let(:module_path) { RSpec.configuration.module_path }
+  let(:config) { { 'modulepath' => module_path } }
+  let(:inventory) { hosts_to_inventory }
+
+  def run(params)
+    run_task('package::linux', 'default', params, config: config, inventory: inventory)
+  end
+
   describe 'install action' do
-    it "install #{package_to_use}" do
-      apply_manifest("package { \"#{package_to_use}\": ensure => absent, }")
-      result = run_task(task_name: 'package::linux', params: "action=install name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{install}, %r{(Job completed. 1/1 nodes succeeded|Ran on 1 node)}])
+    it 'install rsyslog' do
+      apply_manifest_on(default, "package { 'rsyslog': ensure => absent, }")
+      result = run('action' => 'install', 'name' => 'rsyslog')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to match(%r{install})
     end
   end
-  describe 'uninstall action' do
-    it "uninstall #{package_to_use}" do
-      apply_manifest("package { \"#{package_to_use}\": ensure => present, }")
-      result = run_task(task_name: 'package::linux', params: "action=uninstall name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{install}, %r{(Job completed. 1/1 nodes succeeded|Ran on 1 node)}])
-    end
-  end
-  describe 'install specific', if: (fact('operatingsystem') == 'CentOS' && fact('operatingsystemmajrelease') == '7' && pe_install?) do
-    it 'upgrade httpd to a specific version' do
-      result = run_task(task_name: 'package', params: 'action=upgrade name=httpd version=2.4.6-45.el7.centos')
-      expect_multiple_regexes(result: result, regexes: [%r{Job completed. 1/1 nodes succeeded}])
-    end
 
+  describe 'uninstall action' do
+    it 'uninstall rsyslog' do
+      apply_manifest_on(default, "package { 'rsyslog': ensure => present, }")
+      result = run('action' => 'uninstall', 'name' => 'rsyslog')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to match(%r{uninstall})
+    end
+  end
+
+  describe 'upgrade', if: (fact('operatingsystem') == 'CentOS' && fact('operatingsystemmajrelease') == '7') do
     it 'upgrade httpd' do
-      result = run_task(task_name: 'package', params: 'action=upgrade name=httpd')
-      expect_multiple_regexes(result: result, regexes: [%r{Job completed. 1/1 nodes succeeded}])
+      apply_manifest_on(default, 'package { "httpd": ensure => "present", }')
+      result = run('action' => 'upgrade', 'name' => 'httpd')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to match(%r{upgrade})
     end
   end
 end

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -1,37 +1,55 @@
 # run a test task
 require 'spec_helper_acceptance'
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
 
 describe 'windows package task', if: fact('osfamily') == 'windows' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  let(:module_path) { RSpec.configuration.module_path }
+  let(:config) { { 'modulepath' => module_path } }
+  let(:inventory) { hosts_to_inventory }
+
+  def run(params)
+    run_task('package::windows', 'default', params, config: config, inventory: inventory)
+  end
+
   package_to_use = 'notepadplusplus.install'
   before(:all) do
-    hosts.each do |host|
-      on(host, 'cmd.exe /c puppet module install puppetlabs-chocolatey')
-      apply_manifest('include chocolatey')
-    end
+    on(default, 'cmd.exe /c puppet module install puppetlabs-chocolatey')
+    apply_manifest_on(default, 'include chocolatey')
   end
+
   describe 'install action' do
     it "install #{package_to_use}" do
-      apply_manifest("package { \"#{package_to_use}\": ensure => absent, }")
-      result = run_task(task_name: 'package::windows', params: "action=install name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{install}, %r{success}, %r{Ran on 1 node}])
+      apply_manifest_on(default, "package { \"#{package_to_use}\": ensure => absent, }")
+      result = run('action' => 'install', 'name' => package_to_use)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['action']).to match(%r{install})
     end
   end
+
   describe 'uninstall action' do
     it "uninstall #{package_to_use}" do
-      apply_manifest("package { \"#{package_to_use}\": ensure => present, }")
-      result = run_task(task_name: 'package::windows', params: "action=uninstall name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{install}, %r{success}, %r{Ran on 1 node}])
+      apply_manifest_on(default, "package { \"#{package_to_use}\": ensure => present, }")
+      result = run('action' => 'uninstall', 'name' => package_to_use)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['action']).to match(%r{uninstall})
     end
   end
+
   describe 'install specific' do
     it 'upgrade notepad++ to a specific version' do
-      result = run_task(task_name: 'package::windows', params: "action=upgrade name=#{package_to_use} version=7.5.5")
-      expect_multiple_regexes(result: result, regexes: [%r{upgrade}, %r{success}, %r{Ran on 1 node}])
+      result = run('action' => 'upgrade', 'name' => package_to_use, 'version' => '7.5.5')
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['action']).to match(%r{upgrade})
     end
 
     it 'upgrade notepad++' do
-      result = run_task(task_name: 'package::windows', params: "action=upgrade name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{upgrade}, %r{success}, %r{Ran on 1 node}])
+      result = run('action' => 'upgrade', 'name' => package_to_use)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['action']).to match(%r{upgrade})
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,12 +4,10 @@ require 'puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
-require 'beaker-task_helper'
 
 run_puppet_install_helper
 configure_type_defaults_on(hosts)
-install_ca_certs unless pe_install?
-install_bolt_on(hosts) unless pe_install?
+install_ca_certs
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 
@@ -17,8 +15,6 @@ RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
 
-  # Configure all nodes in nodeset
-  c.before :suite do
-    run_puppet_access_login(user: 'admin') if pe_install?
-  end
+  c.add_setting :module_path
+  c.module_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'modules')
 end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -3,11 +3,11 @@
   "input_method": "stdin",
   "parameters": {
     "action": {
-      "description": "The operation (install, status, uninstall and upgrade) to perform on the package",
+      "description": "The operation (install, status, uninstall and upgrade) to perform on the package.",
       "type": "Enum[install, status, uninstall, upgrade]"
     },
     "name": {
-      "description": "The name of the package to be manipulated",
+      "description": "The name of the package to be manipulated.",
       "type": "String[1]"
     },
     "version": {
@@ -15,8 +15,13 @@
       "type": "Optional[String[1]]"
     },
     "provider": {
-      "description": "The provider to use to manage or inspect the package, defaults to the system package manager",
+      "description": "The provider to use to manage or inspect the package, defaults to the system package manager. Only used when the 'puppet-agent' feature is available on the target so we can leverage Puppet.",
       "type": "Optional[String[1]]"
     }
-  }
+  },
+  "implementations": [
+    {"name": "init.rb", "requirements": ["puppet-agent"]},
+    {"name": "windows.ps1", "requirements": ["powershell"], "input_method": "powershell"},
+    {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment"}
+  ]
 }

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,5 +1,6 @@
 {
   "description": "Manage the state of packages (without a puppet agent)",
+  "private": true,
   "input_method": "environment",
   "parameters": {
     "action": {

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -1,5 +1,6 @@
 {
   "description": "Manage the state of packages (without a puppet agent)",
+  "private": true,
   "input_method": "powershell",
   "parameters": {
     "action": {


### PR DESCRIPTION
Add implementations to the init task so it falls back to non-Ruby
implementations when puppet-agent isn't available. Also hide the extra
implementations from task runners that implement private tasks and task
implementations.