### PR TITLE
(BOLT-1104) Rewrite Linux package task and fix status output

### DIFF
--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -32,7 +32,7 @@ describe 'linux package task', unless: fact('osfamily') == 'windows' do
       apply_manifest_on(default, "package { 'rsyslog': ensure => present, }")
       result = run('action' => 'uninstall', 'name' => 'rsyslog')
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{uninstall})
+      expect(result[0]['result']['status']).to match(%r{deinstall ok|uninstalled})
     end
   end
 
@@ -41,7 +41,7 @@ describe 'linux package task', unless: fact('osfamily') == 'windows' do
       apply_manifest_on(default, 'package { "httpd": ensure => "present", }')
       result = run('action' => 'upgrade', 'name' => 'httpd')
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{upgrade})
+      expect(result[0]['result']['status']).to match(%r{install})
     end
   end
 end

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,18 +1,22 @@
 {
-  "description": "Manage the state of packages (without a puppet agent)",
+  "description": "Manage and inspect the state of packages (without a puppet agent)",
   "private": true,
   "input_method": "environment",
   "parameters": {
     "action": {
-      "description": "The action to be applied to the package: install, uninstall, and upgrade.",
-      "type": "Enum[install, uninstall, upgrade]"
+      "description": "The operation (install, status, uninstall and upgrade) to perform on the package.",
+      "type": "Enum[install, status, uninstall, upgrade]"
     },
     "name": {
-      "description": "The name of the package to manage.",
+      "description": "The name of the package to be manipulated.",
       "type": "String[1]"
     },
     "version": {
-      "description": "The version, and if applicable, the release value of the package. A version number range or a semver pattern are not permitted. For example, to install the bash-4.1.2-29.el6.x86_64.rpm package, enter 4.1.2-29.el6.",
+      "description": "Version numbers must match the full version to install, including release if the provider uses a release moniker. Ranges or semver patterns are not accepted except for the gem package provider. For example, to install the bash package from the rpm bash-4.1.2-29.el6.x86_64.rpm, use the string '4.1.2-29.el6'.",
+      "type": "Optional[String[1]]"
+    },
+    "provider": {
+      "description": "The provider to use to manage or inspect the package, defaults to the system package manager. Only used when the 'puppet-agent' feature is available on the target so we can leverage Puppet.",
       "type": "Optional[String[1]]"
     }
   }

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -94,8 +94,8 @@ case "$available_manager" in
     # Use --queryformat to make a json object with status and version
     # yum is ok with including the version in the package name
     # yum returns non-zero if the package isn't installed
-    cmd_status="$(rpm -q --queryformat '\{ "status": "installed", "version": "%{VERSION}" \}' "$package")" || {
-       cmd_status='{ "status": "uninstalled" }'
+    cmd_status="$(rpm -q --queryformat '\{ "status": "success", "package_status": "installed", "version": "%{VERSION}" \}' "$package")" || {
+       cmd_status='{ "status": "success", "package_status": "uninstalled" }'
     }
     success "$cmd_status"
 esac

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -1,61 +1,95 @@
 #!/bin/bash
 
+# example cli /opt/puppetlabs/puppet/bin/bolt task run package::linux action=install name=vim --nodes localhost --modulepath /et c/puppetlabs/code/modules --password puppet --user root
+
+# Exit with an error message and error code, defaulting to 1
+fail() {
+  # Print a message: entry if there were anything printed to stderr
+  if [[ -s $_tmp ]]; then
+    # Hack to try and output valid json by replacing newlines with spaces.
+    echo "{ \"status\": \"error\", \"message\": \"$(tr '\n' ' ' <$_tmp)\" }"
+  else
+    echo '{ "status": "error" }'
+  fi
+
+  exit ${2:-1}
+}
+
+success() {
+  echo "$1"
+  exit 0
+}
+
+# Keep stderr in a temp file.  Easier than `tee` or capturing process substitutions
+_tmp="$(mktemp)"
+exec 2>"$_tmp"
+
 action="$PT_action"
 name="$PT_name"
 version="$PT_version"
+package_managers=("apt-get" "yum")
+options=()
 
-package_managers[0]="yum"
-package_managers[1]="apt-get"
-
-# example cli /opt/puppetlabs/puppet/bin/bolt task run package::linux action=install name=vim --nodes localhost --modulepath /etc/puppetlabs/code/modules --password puppet --user root
-
-check_command_exists() {
-  (which "$1") > /dev/null 2>&1
-  command_exists=$?
-  return ${command_exists}
-}
-
-if [ "${action}" = "uninstall" ]; then
-  action="remove"
-fi
-
-for package_manager in "${package_managers[@]}"
-do
-  check_command_exists "$package_manager"
-  command_exists=$?
-  if [ "${command_exists}" -eq 0 ]; then
-    if [ "${package_manager}" = "yum" ]; then
-      if [ "${version}" != "" ]; then
-        name="$name-$version"
-      fi
-      # upgrading to a specific version needs to use the install action
-      if [ "${version}" != "" ] && [ "${action}" = "upgrade" ]; then
-        action="install"
-      fi
-    else
-      $(export DEBIAN_FRONTEND=noninteractive)
-      if [ "${version}" != "" ]; then
-        name="$name=$version"
-      fi
-      # upgrading requires install to be used. --only-upgrade will not install new packages
-      if [ "${action}" = "upgrade" ]; then
-        action="install --only-upgrade"
-      fi
-    fi
-
-    command_line="$package_manager -y $action $name"
-    output=$(${command_line} 2>&1)
-    status_from_command=$?
-    # set up our status and exit code
-    if [ "${status_from_command}" -eq 0 ]; then
-      echo "{ \"status\": \"$PT_name $PT_action\" }"
-      exit 0
-    else
-      echo "{ \"status\": \"unable to run command '$command_line'\" }"
-      exit ${status_from_command}
-    fi
+for p in "${package_managers[@]}"; do
+  if type "$p" &>/dev/null; then
+    available_manager="$p"
+    break
   fi
 done
 
-echo "{ \"status\": \"No package managers found\" }"
-exit 255
+[[ $available_manager ]] || {
+  echo '{ "status": "No package managers found", "message": "Must be one of: [apt, yum]" }'
+  exit 255
+}
+
+# For any package manager, check if the action is "status". If so, only run a status command
+# Otherwise, run the requested action and follow up with a "status" command
+case "$available_manager" in
+  "apt-get")
+    # quiet and assume yes
+    options+=("-yq")
+
+    # <package>=<version> is the syntax for installing a specific version in apt
+    [[ $version ]] && name="${name}=${version}"
+
+    case "$action" in
+      "uninstall")
+        action="remove"
+        ;;
+      "upgrade")
+        action="install"
+        options+=("--only-upgrade")
+    esac
+
+    [[ $action == "status" ]] || DEBIAN_FRONTEND=noninteractive "apt-get" "$action" "$name" "${options[@]}" >/dev/null || fail
+
+    # Use --showformat to make a json object with status and version
+    # ${name%%=*} removes the version in case we installed a specific one
+    # This will print nothing to stdout if the package is not installed
+    cmd_status="$(dpkg-query --show --showformat='{ "status":"${Status}", "version":"${Version}" }' ${name%%=*})"
+    [[ $cmd_status ]] || cmd_status='{ "status": "uninstalled" }'
+    success "$cmd_status"
+    ;;
+
+  "yum")
+    # assume yes
+    options+=("-y")
+
+    # <package>-<version> is the syntax for installing a specific version in yum
+    [[ $version ]] && name="${name}-${version}"
+
+    case "$action" in
+      "uninstall")
+        action="remove"
+    esac
+
+    [[ $action == "status" ]] || "yum" "$action" "$name" "${options[@]}" >/dev/null || fail
+
+    # Use --queryformat to make a json object with status and version
+    # yum is ok with including the version in the package name
+    # yum returns non-zero if the package isn't installed
+     cmd_status="$(rpm -q --queryformat '\{ "status": "installed", "version": "%{VERSION}" \}' "$name")" || {
+        cmd_status='{ "status": "uninstalled" }'
+     }
+     success "$cmd_status"
+esac

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -38,7 +38,7 @@ for p in "${package_managers[@]}"; do
 done
 
 [[ $available_manager ]] || {
-  echo '{ "status": "No package managers found", "message": "Must be one of: [apt, yum]" }'
+  echo '{ "status": "error", "message": "No package managers found", "message": "Must be one of: [apt, yum]" }'
   exit 255
 }
 
@@ -66,7 +66,7 @@ case "$available_manager" in
     # Use --showformat to make a json object with status and version
     # ${name%%=*} removes the version in case we installed a specific one
     # This will print nothing to stdout if the package is not installed
-    cmd_status="$(dpkg-query --show --showformat='{ "status":"${Status}", "version":"${Version}" }' ${name%%=*})"
+    cmd_status="$(dpkg-query --show --showformat='{ "status": "success", "package_status":"${Status}", "version":"${Version}" }' ${name%%=*})"
     [[ $cmd_status ]] || cmd_status='{ "status": "uninstalled" }'
     success "$cmd_status"
     ;;


### PR DESCRIPTION
Return information from the package command itself, i.e. yum or apt.
Also provide the error message as part of the json object.
Directly check the return code of commands instead of storing
$? in a variable when we can.  Use mktmp and exec to manage stderr.