### PR TITLE
(MODULES-8717) Fix for boltspec run dependancy issue

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -1,7 +1,5 @@
 # run a test task
 require 'spec_helper_acceptance'
-require 'beaker-task_helper/inventory'
-require 'bolt_spec/run'
 
 describe 'package task' do
   include Beaker::TaskHelper::Inventory

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -1,7 +1,5 @@
 # run a test task
 require 'spec_helper_acceptance'
-require 'beaker-task_helper/inventory'
-require 'bolt_spec/run'
 
 describe 'linux package task', unless: fact('osfamily') == 'windows' do
   include Beaker::TaskHelper::Inventory

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -1,7 +1,5 @@
 # run a test task
 require 'spec_helper_acceptance'
-require 'beaker-task_helper/inventory'
-require 'bolt_spec/run'
 
 describe 'windows package task', if: fact('osfamily') == 'windows' do
   include Beaker::TaskHelper::Inventory

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'bolt_spec/run'
+require 'beaker-task_helper/inventory'
 require 'beaker-pe'
 require 'beaker-puppet'
 require 'puppet'


### PR DESCRIPTION
Moving the requires causing dependancy issues to the spec_helper_acceptance so they don't conflict with each other.