### PR TITLE
(SEN-795) Move extension metadata to init.json

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -23,5 +23,11 @@
     {"name": "init.rb", "requirements": ["puppet-agent"]},
     {"name": "windows.ps1", "requirements": ["powershell"], "input_method": "powershell"},
     {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment"}
-  ]
+  ],
+  "extensions": {
+    "discovery": {
+      "friendlyName": "Manage package",
+      "type": ["package"]
+    }
+  }
 }

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -15,12 +15,5 @@
       "description": "The version, and if applicable, the release value of the package. A version number range or a semver pattern are not permitted. For example, to install the bash-4.1.2-29.el6.x86_64.rpm package, enter 4.1.2-29.el6.",
       "type": "Optional[String[1]]"
     }
-  },
-  "extensions": {
-    "discovery": {
-      "friendlyName": "Manage package on Linux",
-      "osFamily": "linux",
-      "type": ["package"]    
-    }
   }
 }

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -15,12 +15,5 @@
       "description": "The version, and if applicable, the release value of the package. A version number range or a semver pattern are not permitted. For example, to install the bash-4.1.2-29.el6.x86_64.rpm package, enter 4.1.2-29.el6.",
       "type": "Optional[String[1]]"
     }
-  },
-  "extensions": {
-    "discovery": {
-      "friendlyName": "Manage package on Windows",
-      "osFamily": "windows",
-      "type": ["package"]
-    }
   }
 }


### PR DESCRIPTION
windows.json and linux.json are private tasks and won't be surfaced. For this reason the discovery extension metadata should only be added into the init.json file