### PR TITLE
Fix package task for yum when passing version

### DIFF
--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -72,7 +72,7 @@ case "$available_manager" in
     provided_package="$(rpm -q --whatprovides "$name")" || provided_package=
 
     # <package>-<version> is the syntax for installing a specific version in yum
-    [[ $version ]] && name="${name}-${version}"
+    [[ $version ]] && full_name="${name}-${version}" || full_name="${name}"
 
     # For Ruby compatibility, 'status' and 'install' will check if the package is upgradable
     case "$action" in
@@ -81,14 +81,14 @@ case "$available_manager" in
         ;;
 
       "install")
-        yum install "$name" "${options[@]}" >/dev/null || fail
+        yum install "$full_name" "${options[@]}" >/dev/null || fail
         # Check for this again after installing
         provided_package="$(rpm -q --whatprovides "$name")" || provided_package=
         yum_check_latest
         ;;
 
       "uninstall")
-        yum remove "$name" "${options[@]}" >/dev/null || fail
+        yum remove "$full_name" "${options[@]}" >/dev/null || fail
         cmd_status="$(yum_status '\{ "status": "installed", "version": "%{VERSION}-%{RELEASE}" \}')" || {
           cmd_status='{ "status": "uninstalled" }'
         }
@@ -104,8 +104,8 @@ case "$available_manager" in
 
         # Why does yum upgrade not return non-zero on a nonexistent package...
         # Because of this, check the output
-        yum_out=$(yum upgrade "$name" "${options[@]}") || fail
-        [[ $yum_out =~ "No package $name available" ]] && fail
+        yum_out=$(yum upgrade "$full_name" "${options[@]}") || fail
+        [[ $yum_out =~ "No package $full_name available" ]] && fail
 
         # For Ruby compatibility, this command uses a different output format
         # Check for this again after installing


### PR DESCRIPTION
This fixes issue https://github.com/puppetlabs/puppetlabs-package/issues/236
## Summary
If the (optional) version parameter is passed the package $name variable is overwritten with "name-version". This format is required by yum when installing/uninstalling/upgrading a specific package version but it is not compatible when calling `rpm -q --whatprovides $name` - which requires the name only.
## Solution
Don't overwrite $name with name-version, use a new variable instead.
## Testing
```
❯ bolt task run package -t 'fiendish-sister.delivery.puppetlabs.net' --params '{"action":"install", "name":"vim-enhanced", "version":"2:8.0.1763-15.el8"}'

Started on fiendish-sister.delivery.puppetlabs.net...
Finished on fiendish-sister.delivery.puppetlabs.net:
  {
    "status": "installed",
    "version": "8.0.1763-15.el8"
  }
Successful on 1 target: fiendish-sister.delivery.puppetlabs.net
Ran on 1 target in 18.03 sec
```
```
❯ bolt task run package -t 'fiendish-sister.delivery.puppetlabs.net' --params '{"action":"upgrade", "name":"openldap", "version":"2.4.46-15.el8"}'

Started on fiendish-sister.delivery.puppetlabs.net...
Finished on fiendish-sister.delivery.puppetlabs.net:
  {
    "old_version": "2.4.46-9.el8",
    "version": "2.4.46-15.el8"
  }
Successful on 1 target: fiendish-sister.delivery.puppetlabs.net
Ran on 1 target in 13.87 sec
```
```
❯ bolt task run package -t 'fiendish-sister.delivery.puppetlabs.net' --params '{"action":"uninstall", "name":"vim-enhanced", "version":"2:8.0.1763-15.el8"}'

Started on fiendish-sister.delivery.puppetlabs.net...
Finished on fiendish-sister.delivery.puppetlabs.net:
  {
    "status": "uninstalled"
  }
Successful on 1 target: fiendish-sister.delivery.puppetlabs.net
Ran on 1 target in 12.82 sec
```
## Affected Area
Package task (for yum only)