### PR TITLE
pdksync - (maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,13 +13,13 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -28,7 +28,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -36,7 +35,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -47,11 +45,12 @@
       "operatingsystemrelease": [
         "14.04",
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {
-      "operatingsystem": "windows",
+      "operatingsystem": "Windows",
       "operatingsystemrelease": [
         "2008 R2",
         "2012 R2",

--- a/provision.yaml
+++ b/provision.yaml
@@ -14,12 +14,14 @@ travis_deb:
   images:
   - litmusimage/debian:8
   - litmusimage/debian:9
+  - litmusimage/debian:10
 travis_ub:
   provisioner: docker
   images:
   - litmusimage/ubuntu:14.04
   - litmusimage/ubuntu:16.04
   - litmusimage/ubuntu:18.04
+  - litmusimage/ubuntu:20.04
 travis_el7:
   provisioner: docker
   images:


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.18.1` 
