### PR TITLE
Expose package manager options to task

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -14,6 +14,10 @@
       "description": "Version numbers must match the full version to install, including release if the provider uses a release moniker. Ranges or semver patterns are not accepted except for the gem package provider. For example, to install the bash package from the rpm bash-4.1.2-29.el6.x86_64.rpm, use the string '4.1.2-29.el6'.",
       "type": "Optional[String[1]]"
     },
+     "manager_options": {
+      "description": "options to be sent to the package manager",
+      "type": "Optional[String[1]]"
+    },
     "provider": {
       "description": "The provider to use to manage or inspect the package, defaults to the system package manager. Only used when the 'puppet-agent' feature is available on the target so we can leverage Puppet.",
       "type": "Optional[String[1]]"

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -11,6 +11,10 @@
       "description": "The name of the package to be manipulated.",
       "type": "String[1]"
     },
+    "manager_options": {
+      "description": "options to be sent to the package manager",
+      "type": "Optional[String[1]]"
+    },
     "version": {
       "description": "Version numbers must match the full version to install, including release if the provider uses a release moniker. Ranges or semver patterns are not accepted except for the gem package provider. For example, to install the bash package from the rpm bash-4.1.2-29.el6.x86_64.rpm, use the string '4.1.2-29.el6'.",
       "type": "Optional[String[1]]"

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -27,6 +27,9 @@ case "$available_manager" in
   "apt-get")
     # quiet and assume yes
     options+=("-yq")
+  
+
+    [ ! -z "$manager_options" ]  && options+=("$manager_options")
 
     # <package>=<version> is the syntax for installing a specific version in apt
     [[ $version ]] && name="${name}=${version}"
@@ -66,6 +69,8 @@ case "$available_manager" in
     # assume yes
     options+=("-y")
 
+    [ ! -z "$manager_options" ] &&  options+=("$manager_options")
+    
     # yum install <pkg> and rpm -q <pkg> may produce different results because one package may provide another
     # For example, 'vim' can be installed because the 'vim-enhanced' package provides 'vim'
     # So, find out the exact package to get the status for
@@ -119,6 +124,7 @@ case "$available_manager" in
     # Non-interactive and no color
     options+=("-n")
 
+    [ ! -z "$manager_options" ] && options+=("$manager_options")
     # <package>-<version> is the syntax for installing a specific version in zypper
     [[ $version ]] && name="${name}-${version}"
 


### PR DESCRIPTION
Prior to this commit, there was no way to pass options to the package manager, this adds an optional parameter called "manager_options" which is conditionally added to the options() array should it be populated