### PR TITLE
pdksync - (CONT-189) Remove support for RedHat6 / OracleLinux6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8",
         "9"

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
CONT-189/remove_os_support
pdk version: `2.5.0` 
