### PR TITLE
(MAINT) Remove references to beaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,11 @@ For information on the classes and types, see the [REFERENCE.md](https://github.
 
 ## Limitations
 
-To run acceptance tests against Windows machines, ensure that the `BEAKER_password` environment variable has been set to the password of the Administrator user of the target machine.
-
 For an extensive list of supported operating systems, see [metadata.json](https://github.com/puppetlabs/puppetlabs-package/blob/main/metadata.json)
 
 ## Development
 
-We are experimenting with a new tool for running acceptance tests. Its name is [puppet_litmus](https://github.com/puppetlabs/puppet_litmus) this replaces beaker as the test runner. To run the acceptance tests follow the instructions from this point [here](https://github.com/puppetlabs/puppet_litmus/wiki/Tutorial:-use-Litmus-to-execute-acceptance-tests-with-a-sample-module-(MoTD)#install-the-necessary-gems-for-the-module).
+Tests are ran using [puppet_litmus](https://github.com/puppetlabs/puppet_litmus). To run the acceptance tests follow the instructions from this point [here](https://github.com/puppetlabs/puppet_litmus/wiki/Tutorial:-use-Litmus-to-execute-acceptance-tests-with-a-sample-module-(MoTD)#install-the-necessary-gems-for-the-module).
 
 Puppet modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. To contribute to Puppet projects, see our [module contribution guide.](https://github.com/puppetlabs/puppetlabs-package/blob/main/CONTRIBUTING.md)
 


### PR DESCRIPTION
Prior to this commit the README referenced usage of beaker. 

I have removed all references to beaker as it is no longer used or relevant for our test infrastructure.