### PR TITLE
Fix shebangs

### DIFF
--- a/files/apt.sh
+++ b/files/apt.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # $1 = string literal to feed to dpkg-query. include json formatting
 # No error check here because querying the status of uninstalled packages will return non-zero
 # Use --showformat to make a json object with status and version

--- a/files/common.sh
+++ b/files/common.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # TODO: helper task?
 
 # Exit with an error message and error code, defaulting to 1

--- a/files/yum.sh
+++ b/files/yum.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # $1 = string literal to feed to rpm -q. include json formatting
 # Use --queryformat to make a json object with status and version
 # yum returns non-zero if the package isn't installed

--- a/files/zypper.sh
+++ b/files/zypper.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # zypper supports xml output for parsing, but we're not guaranteed to have a parser
 zypper_status() {
   installed_version

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # example: bolt task run package::linux action=install name=rsyslog
 


### PR DESCRIPTION
`bash(1)` is not always installed in `/bin`, we can only assume
`/bin/sh` is a bourne shell, and for any other non-portable shell rely
on `env(1)` (always available as `/usr/bin/env`) to find the appropriate
command in `$PATH`.

While here, remove shebangs from non-executable files.
