### PR TITLE
Add Compatibility with FreeBSD

### DIFF
--- a/files/pkg.sh
+++ b/files/pkg.sh
@@ -1,0 +1,23 @@
+# $1 = string literal to feed to pkg-query. include json formatting
+# No error check here because querying the status of uninstalled packages will return non-zero
+# Use the format string to make a json object with status and version
+# This will print nothing to stdout if the package is not installed
+pkg_status() {
+  pkg query "$1" "${name}"
+}
+
+# Determine if newer package is available to mirror the ruby/puppet implementation
+pkg_check_latest() {
+  installed="$(pkg_status '%v')"
+  [ -z "$installed" ] && success '{ "status": "uninstalled", "version": ""}'
+
+  candidate=$(pkg rquery '%v' "$name")
+
+  if [ "$installed" != "$candidate" ]; then
+    cmd_status="{ \"status\":\"installed\", \"version\":\"${installed}\", \"latest\":\"${candidate}\" }"
+  else
+    cmd_status="$(pkg_status '{ "status":"installed", "version":"%v" }')"
+  fi
+
+  success "$cmd_status"
+}

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -26,7 +26,7 @@
   "implementations": [
     {"name": "init.rb", "requirements": ["puppet-agent"]},
     {"name": "windows.ps1", "requirements": ["powershell"], "input_method": "powershell"},
-    {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment", "files": ["package/files/common.sh", "package/files/apt.sh", "package/files/yum.sh", "package/files/zypper.sh"]}
+    {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment", "files": ["package/files/common.sh", "package/files/apt.sh", "package/files/pkg.sh", "package/files/yum.sh", "package/files/zypper.sh"]}
   ],
   "extensions": {
     "discovery": {


### PR DESCRIPTION
Add support for managing FreeBSD packages.  For now the module depend on
bash which is not part of a default FreeBSD install.

Depends on:
* #305
