### PR TITLE
(CONT-1178) - Fixing build failures

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -45,7 +45,7 @@ function Invoke-PackageAction($Package, $Action, $Version)
 
   if ($Action -eq "status")
   {
-    $commandLine += " search $Package -y --exact --lo --limit-output"
+    $commandLine += " list $Package --limit-output"
   } else {
     $commandLine += " $Action $Package -y"
 


### PR DESCRIPTION
## Summary
Build is failing while checking choco package status check.

## Additional Context
Updating package discovery from search to list as search is giving from upstream but list just limit local installation : 
When NOT installed :
```
PS C:\Windows\system32> choco search notepadplusplus.install --exact --limit-output
notepadplusplus.install|8.5.4
PS C:\Windows\system32> choco list notepadplusplus.install --limit-output
PS C:\Windows\system32>
```
When installed : 
```
PS C:\Windows\system32> choco search notepadplusplus.install --exact --limit-output
notepadplusplus.install|8.5.4
PS C:\Windows\system32> choco list notepadplusplus.install --limit-output
notepadplusplus.install|8.5.4
```

## Related Issues (if any)
- N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)