### PR TITLE
Ensure rpm --whatprovides is deduplicated

### DIFF
--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -109,8 +109,9 @@ case "$available_manager" in
     
     # yum install <pkg> and rpm -q <pkg> may produce different results because one package may provide another
     # For example, 'vim' can be installed because the 'vim-enhanced' package provides 'vim'
-    # So, find out the exact package to get the status for
-    provided_package="$(rpm -q --whatprovides "$name")" || provided_package=
+    # So, find out the exact package to get the status for. Ensure the results are de-duplicated
+    # for packages which may match the whatprovides query more than once.
+    provided_package="$(rpm -q --whatprovides "$name" | sort -u)" || provided_package=
 
     # <package>-<version> is the syntax for installing a specific version in yum
     [[ $version ]] && full_name="${name}-${version}" || full_name="${name}"


### PR DESCRIPTION
Some RPM packages may have provides such that the package matches the query multiple times, causing RPM to return the package name multiple times. This change ensures that if that occurs it is properly de-duplicated.
